### PR TITLE
Add page for receiving samples by barcode

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@material-ui/core": "^1.1.0",
+    "mdi-material-ui": "^5.1.1",
     "react": "^16.4.0",
     "react-dom": "^16.4.0",
     "react-router-dom": "^4.3.1",

--- a/src/App.js
+++ b/src/App.js
@@ -4,6 +4,11 @@ import styled from "styled-components"
 
 import TabView from "./TabView"
 
+import Receive from "./Receive"
+import Test from "./Test"
+import Review from "./Review"
+import Release from "./Release"
+
 const App = (state) => (
   <Router>
     <Layout>
@@ -11,10 +16,10 @@ const App = (state) => (
 
       <TabView
         tabs={{
-          receive: () => <PageContent />,
-          test: () => <PageContent />,
-          review: () => <PageContent />,
-          release: () => <PageContent />,
+          receive: () => <Receive onReceive={console.log} />,
+          test: () => <Test />,
+          review: () => <Review />,
+          release: () => <Release />,
         }} />
     </Layout>
   </Router>
@@ -28,11 +33,6 @@ const Layout = styled.div`
 
 const Sidebar = styled.div`
 background-color: blue;
-`
-
-const PageContent = styled.div`
-  height: 10rem;
-  background-color: black;
 `
 
 export default App

--- a/src/BarcodeField.js
+++ b/src/BarcodeField.js
@@ -1,0 +1,41 @@
+import React from "react"
+
+class BarcodeField extends React.Component {
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      timer: null,
+      value: "",
+    }
+  }
+
+  render() {
+    return (
+      <input
+        type="text"
+        ref={(element) => { this.field = element } }
+        value={this.state.value}
+        onChange={(e) => {
+          clearTimeout(this.state.timer)
+          this.setState({
+            value: e.target.value,
+            timer: setTimeout(this.submit.bind(this), 500),
+          })
+        }}
+      />
+    )
+  }
+
+  submit() {
+    this.props.onScan(this.state.value)
+    this.setState({ value: "", timer: null })
+  }
+
+  componentDidMount() {
+    if(this.props.focus)
+      this.field.focus()
+  }
+}
+
+export default BarcodeField

--- a/src/Receive.js
+++ b/src/Receive.js
@@ -1,0 +1,28 @@
+import React from "react"
+import styled from "styled-components";
+
+import { BarcodeScan } from "mdi-material-ui"
+import BarcodeField from "./BarcodeField"
+
+const Receive = ({onReceive}) => (
+  <Layout>
+    <Media.BarcodeScan />
+
+    <p>Scan a barcode to begin.</p>
+    <p>
+      <BarcodeField focus onScan={(value) => onReceive(value)} />
+    </p>
+  </Layout>
+)
+
+const Layout = styled.div`
+text-align: center;
+`
+
+const Media = {}
+Media.BarcodeScan = styled(BarcodeScan)`
+height: 8rem !important;
+width: 8rem !important;
+`
+
+export default Receive

--- a/src/Release.js
+++ b/src/Release.js
@@ -1,0 +1,8 @@
+import styled from "styled-components";
+
+const Release = styled.div`
+  height: 10rem;
+  background-color: black;
+`
+
+export default Release

--- a/src/Review.js
+++ b/src/Review.js
@@ -1,0 +1,8 @@
+import styled from "styled-components";
+
+const Review = styled.div`
+  height: 10rem;
+  background-color: black;
+`
+
+export default Review

--- a/src/Test.js
+++ b/src/Test.js
@@ -1,0 +1,8 @@
+import styled from "styled-components";
+
+const Test = styled.div`
+  height: 10rem;
+  background-color: black;
+`
+
+export default Test

--- a/yarn.lock
+++ b/yarn.lock
@@ -4542,6 +4542,10 @@ md5.js@^1.3.4:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
+mdi-material-ui@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/mdi-material-ui/-/mdi-material-ui-5.1.1.tgz#5cbe5afb44705fd14cb4517019d9778ccf48454f"
+
 media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"


### PR DESCRIPTION
Barcode scanners essentially act as keyboards,
sending a bunch of keystrokes really quickly.

We figure a scan is complete when half a second elapses
with no new keystrokes.

## Implementation Details

Icon is the `barcode-scan` icon from:

* https://materialdesignicons.com/
* See https://github.com/TeamWertarbyte/mdi-material-ui
* See https://material-ui.com/style/icons/

Auto-focus on text field courtesy of:

* https://stackoverflow.com/questions/28889826/react-set-focus-on-input-after-render