### PR TITLE
Add timestamps to application events

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ partNo text not null,
 customer text not null,
 item text not null,
 received_by text not null,
+received_at timestamp not null,
 primary key(id)
 );
 
@@ -54,6 +55,7 @@ sample_id text not null,
 test_name text not null,
 result text not null,
 entered_by text not null,
+entered_at timestamp not null,
 pass boolean not null
 );
 ```

--- a/src/App.js
+++ b/src/App.js
@@ -120,13 +120,14 @@ class App extends React.Component {
     .then(csvParse)
     .then((samples) => samples.forEach((sampleInfo) => this.assemble.run("slim")`
       insert into samples
-      (id, partNo, item, customer, received_by)
+      (id, partNo, item, customer, received_by, received_at)
       values (
       '${sampleInfo.id}',
       '${sampleInfo.part}',
       '${sampleInfo.item}',
       '${sampleInfo.customer}',
-      '${this.state.user.name}'
+      '${this.state.user.name}',
+      (TIMESTAMP '${(new Date()).toJSON()}')
       )
     `))
   }

--- a/src/Receive.js
+++ b/src/Receive.js
@@ -47,7 +47,7 @@ To test out this system, copy & paste one of these:
                   {sample.item}
                 </T>
 
-                <T variant="caption" align="left">Received by {sample.received_by}</T>
+                <T variant="caption" align="left">{sample.received_by} received at {sample.received_at}</T>
               </div>
 
               <div>

--- a/src/TestSpecification.js
+++ b/src/TestSpecification.js
@@ -38,20 +38,23 @@ class TestSpecification extends React.Component {
         />
 
         {this.state.recordedResult
-        ? `Recorded by ${this.state.recordedResult.entered_by}`
+        ? <T>{this.state.recordedResult.entered_by} recorded at
+          <T variant="caption">{this.state.recordedResult.entered_at}</T>
+          </T>
         : <Button
             // TODO this automatically assumes that it passes.
             // We should have a callback to help determine whether it does or not.
             onClick={(result, source) =>
               this.assemble.run("slim")`
                 insert into results
-                (sample_id, test_name, result, pass, entered_by)
+                (sample_id, test_name, result, pass, entered_by, entered_at)
                 values (
                   '${this.props.sample_id}',
                   '${this.props.name}',
                   '${this.state.value}',
                   ${true},
-                  '${this.props.user.name}'
+                  '${this.props.user.name}',
+                  (TIMESTAMP '${(new Date()).toJSON()}')
                 )
               `
             }


### PR DESCRIPTION
Closes #31

Add timestamps to the "Receive sample" and "Enter test results" events.