### PR TITLE
Add status logic for completing/releasing samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ id text not null,
 partNo text not null,
 customer text not null,
 item text not null,
+status text not null,
 received_by text not null,
 received_at timestamp not null,
 primary key(id)

--- a/src/Release.js
+++ b/src/Release.js
@@ -16,7 +16,7 @@ class Release extends React.Component {
         {this.props.samples.length === 0
           ? <div>
               <T align="center">No samples in the system aare completed.</T>
-              <T align="center">Maybe <Link to="/receive">see if anything needs testing?</Link></T>
+              <T align="center">Maybe <Link to="/test">see if anything needs testing?</Link></T>
             </div>
           : null
         }
@@ -32,7 +32,9 @@ class Release extends React.Component {
             </ExpansionPanelDetails>
 
             <ExpansionPanelActions>
-              <Button>Release</Button>
+              <Button onClick={() => this.props.onRelease(sample.id)}>
+                Release
+              </Button>
             </ExpansionPanelActions>
           </ExpansionPanel>
         ))}

--- a/src/Test.js
+++ b/src/Test.js
@@ -32,6 +32,7 @@ class Test extends React.Component {
               {React.createElement(lookupTestPlan(sample.partno), {
                 sample_id: sample.id,
                 user: this.props.user,
+                onSampleCompleted: this.props.onSampleCompleted,
               })}
             </ExpansionPanelDetails>
           </ExpansionPanel>
@@ -49,6 +50,9 @@ const lookupTestPlan = (partNo) => (
 )
 
 class TestPlan0123123456 extends React.Component {
+  recordedResults = 0
+  numTests = 3
+
   render() {
     return (
       <div>
@@ -58,6 +62,7 @@ class TestPlan0123123456 extends React.Component {
           name="Appearance"
           method="Visual"
           criteria="White to off-white cream"
+          onComplete={() => this.recordResult()}
         />
 
         <TestSpecification
@@ -66,6 +71,7 @@ class TestPlan0123123456 extends React.Component {
           sample_id={this.props.sample_id}
           method="Organoleptic"
           criteria="Characteristic"
+          onComplete={() => this.recordResult()}
         />
 
         <TestSpecification
@@ -74,9 +80,18 @@ class TestPlan0123123456 extends React.Component {
           name="pH"
           method="USP"
           criteria="6.0 - 7.0"
+          onComplete={() => this.recordResult()}
         />
       </div>
     )
+  }
+
+  recordResult() {
+    this.recordedResults += 1
+
+    if(this.recordedResults == this.numTests) {
+      this.props.onSampleCompleted(this.props.sample_id)
+    }
   }
 }
 

--- a/src/TestSpecification.js
+++ b/src/TestSpecification.js
@@ -21,6 +21,9 @@ class TestSpecification extends React.Component {
     `((results) => {
       let recordedResult = csvParse(results)[0]
       this.setState({ recordedResult: recordedResult || null })
+
+      if(recordedResult)
+        this.props.onComplete()
     })
   }
 


### PR DESCRIPTION
This gets rid of the hard-coded 3-test count for samples.

Closes #38
Closes #37