### PR TITLE
Add a page for samples that have been released

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -3,13 +3,14 @@ import { BrowserRouter as Router, Route, Redirect } from "react-router-dom"
 import styled from "styled-components"
 
 import Assemble from "./Assemble"
+import History from "./History"
 import Receive from "./Receive"
 import Release from "./Release"
 import Sidebar from "./Sidebar"
+import SignIn from "./SignIn"
 import TabView from "./TabView"
 import Test from "./Test"
 import csvParse from "./csvParse"
-import SignIn from "./SignIn"
 
 class App extends React.Component {
   assemble = new Assemble("http://localhost:3000")
@@ -17,6 +18,7 @@ class App extends React.Component {
   state = {
     receivedSamples: [],
     samplesWithCompletedTests: [],
+    releasedSamples: [],
     user: null,
   }
 
@@ -70,6 +72,9 @@ class App extends React.Component {
                     onRelease={(sampleID) => this.release(sampleID)}
                     samples={this.state.samplesWithCompletedTests}
                   />,
+                history: () => <History
+                  samples={this.state.releasedSamples}
+                />
               }} />
           : <Redirect to="/sign_in" />
           }
@@ -92,8 +97,11 @@ class App extends React.Component {
       where status = 'Received'
     `((result) => this.setState({ receivedSamples: csvParse(result) }))
 
-    // TODO: this logic for a "completed" sample is flawed -
-    // it assumes there are exactly three tests defined for a sample.
+    this.assemble.watch("slim")`
+      select * from samples
+      where status = 'Released'
+    `((result) => this.setState({ releasedSamples: csvParse(result) }))
+
     this.assemble.watch("slim")`
       select * from samples
       where status = 'Completed'

--- a/src/History.js
+++ b/src/History.js
@@ -1,0 +1,40 @@
+import React from "react"
+
+import ExpandMoreIcon from "@material-ui/icons/ExpandMore"
+import ExpansionPanel from "@material-ui/core/ExpansionPanel"
+import ExpansionPanelDetails from "@material-ui/core/ExpansionPanelDetails"
+import ExpansionPanelSummary from "@material-ui/core/ExpansionPanelSummary"
+import ExpansionPanelActions from "@material-ui/core/ExpansionPanelActions"
+import Button from "@material-ui/core/Button"
+import T from "@material-ui/core/Typography"
+import { Link } from "react-router-dom"
+
+class History extends React.Component {
+  render() {
+    return (
+      <div>
+        {this.props.samples.length === 0
+          ? <div>
+              <T align="center">No samples in the system aare completed.</T>
+              <T align="center">Maybe <Link to="/test">see if anything needs testing?</Link></T>
+            </div>
+          : null
+        }
+
+        {this.props.samples.map((sample) => (
+          <ExpansionPanel key={sample.id}>
+            <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
+              <T>[{sample.id}] {sample.customer}: {sample.item}</T>
+            </ExpansionPanelSummary>
+
+            <ExpansionPanelDetails>
+              Something?
+            </ExpansionPanelDetails>
+          </ExpansionPanel>
+        ))}
+      </div>
+    );
+  }
+}
+
+export default History


### PR DESCRIPTION
For now, this is a duplicate of the `Release` page,
without the actions on each sample.

Closes #28