### PR TITLE
Fix redirect bug with sign in

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -23,7 +23,7 @@ class App extends React.Component {
     samplesWithCompletedTests: [],
     samplesWithoutSpecifications: [],
     specifications: [],
-    user: null,
+    user: undefined,
   }
 
   render() {
@@ -86,7 +86,7 @@ class App extends React.Component {
                   samples={this.state.releasedSamples}
                 />
               }} />
-          : <Redirect to="/sign_in" />
+          : this.state.user === null ? <Redirect to="/sign_in" /> : null
           }
         </Layout>
       </Router>
@@ -100,6 +100,8 @@ class App extends React.Component {
         name: localStorage.getItem("user_name"),
         username: localStorage.getItem("user_username"),
       }})
+    } else {
+      this.setState({ user: null })
     }
 
     this.assemble.watch("slim")`


### PR DESCRIPTION
Closes #43.

Make use of Javascript's distinct `null` and `undefined` concepts
to mark whether the user is not-signed-in,
vs if they simply haven't been loaded into the state yet.

Only redirect to the sign in page if nobody is signed in;
don't redirect if we haven't loaded them from localStorage yet.