### PR TITLE
Clean up Assemble references after using them

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,16 +145,20 @@ let callback_function = function(result) {
 
 // Repeatedly run this code every time `system_name` gets an update.
 // `watch` only accepts a single callback function.
-this.assemble.watch("system_name")`
+assemble.watch("system_name")`
   code.to(run)
 `(callback_function)
 
 // `run` allows chainable callback functions using the `then` function.
-this.assemble.run("system_name")`
+assemble.run("system_name")`
   code.to(run)
 `
 .then(callback)
 .then(callback)
+
+// Be sure to clean up when you're done.
+
+assemble.destruct()
 ```
 
 ## `create-react-app` Table of Contents

--- a/src/App.js
+++ b/src/App.js
@@ -140,6 +140,10 @@ class App extends React.Component {
     `((result) => this.setState({ specifications: csvParse(result) }))
   }
 
+  componentWillUnmount() {
+    this.assemble.destruct()
+  }
+
   fetchSampleInfo(sampleNo) {
     this.assemble.run("accupacDatabase")`
       select

--- a/src/Assemble.js
+++ b/src/Assemble.js
@@ -4,6 +4,7 @@ class Assemble {
   constructor(url) {
     this.url = url
     this.watches = {}
+    this.active = true
   }
 
   run(system) {
@@ -21,7 +22,7 @@ class Assemble {
       })
     }).then((result) => {
       let watches = this.watches[system]
-      if(watches !== undefined) {
+      if(this.active && watches !== undefined) {
         watches.forEach((watch) => {
           watch()
         })
@@ -31,8 +32,6 @@ class Assemble {
     })
   }
 
-  // For now, this only executes the command a single time.
-  // It is an alias for the `system` function.
   watch(system) {
     if(this.watches[system] === undefined) {
       this.watches[system] = []
@@ -49,8 +48,8 @@ class Assemble {
             url: "/evaluate",
             type: "POST",
             data: { system, code },
-            success: callback,
-            error: callback,
+            success: (result) => { if(this.active) { callback(result) } },
+            error: (result) => { if(this.active) { callback(result) } },
           })
 
         this.watches[system].push(watch)
@@ -59,6 +58,11 @@ class Assemble {
     }
 
     return templating
+  }
+
+  destruct() {
+    this.watches = {}
+    this.active = false
   }
 }
 

--- a/src/Sample.js
+++ b/src/Sample.js
@@ -52,6 +52,10 @@ class Sample extends React.Component {
     })
   }
 
+  componentWillUnmount() {
+    this.assemble.destruct()
+  }
+
   render() {
     return (
       <ExpansionPanel>

--- a/src/SignIn.js
+++ b/src/SignIn.js
@@ -57,6 +57,10 @@ class SignIn extends React.Component {
   parseLDAPResultForUserInfo(ldapResult) {
     // TODO
   }
+
+  componentWillUnmount() {
+    this.assemble.destruct()
+  }
 }
 
 const stubUserInfo = () => {


### PR DESCRIPTION
Fixes #50
CC @mattyayoh

## Problem

We were firing off AJAX requests on behalf of components
which were then unmounted from the DOM.

When the AJAX requests returned a result,
callbacks were called that were no longer applicable.

## Solution

Add an `Assemble#destruct()` function
to prevent the Assemble object from calling any further callbacks.