### PR TITLE
Use TSV to avoid Commas-in-db-field errors

### DIFF
--- a/server/app/controllers/code_controller.rb
+++ b/server/app/controllers/code_controller.rb
@@ -11,8 +11,8 @@ class CodeController < ApplicationController
 
       # This returns a SQL result in pretty-close-to-CSV format
       render plain: [
-        result.columns.join(","),
-        result.rows.map {|row| row.join(",") },
+        result.columns.join("\t"),
+        result.rows.map {|row| row.join("\t") },
       ].join("\n")
     elsif params[:system] == "accupacDatabase"
       sample_data = File.read(Rails.root.join("../data.json"))

--- a/src/App.js
+++ b/src/App.js
@@ -11,7 +11,7 @@ import SignIn from "./SignIn"
 import Specify from "./Specify"
 import TabView from "./TabView"
 import Test from "./Test"
-import csvParse from "./csvParse"
+import { tsvParse } from "./csvParse"
 
 class App extends React.Component {
   assemble = new Assemble("http://localhost:3000")
@@ -112,32 +112,32 @@ class App extends React.Component {
     this.assemble.watch("slim")`
       select * from samples
       where status = 'Received'
-    `((result) => this.setState({ receivedSamples: csvParse(result) }))
+    `((result) => this.setState({ receivedSamples: tsvParse(result) }))
 
     this.assemble.watch("slim")`
       select * from samples
       where status = 'Received'
       and partno in (select distinct partno from specification)
-    `((result) => this.setState({ samplesForTesting: csvParse(result) }))
+    `((result) => this.setState({ samplesForTesting: tsvParse(result) }))
 
     this.assemble.watch("slim")`
       select * from samples
       where status = 'Released'
-    `((result) => this.setState({ releasedSamples: csvParse(result) }))
+    `((result) => this.setState({ releasedSamples: tsvParse(result) }))
 
     this.assemble.watch("slim")`
       select * from samples
       where status = 'Completed'
-    `((result) => this.setState({ samplesWithCompletedTests: csvParse(result) }))
+    `((result) => this.setState({ samplesWithCompletedTests: tsvParse(result) }))
 
     this.assemble.watch("slim")`
       select * from samples
       where partno not in (select distinct partno from specification)
-    `((result) => this.setState({ samplesWithoutSpecifications: csvParse(result) }))
+    `((result) => this.setState({ samplesWithoutSpecifications: tsvParse(result) }))
 
     this.assemble.watch("slim")`
       select * from specification
-    `((result) => this.setState({ specifications: csvParse(result) }))
+    `((result) => this.setState({ specifications: tsvParse(result) }))
   }
 
   componentWillUnmount() {
@@ -158,7 +158,7 @@ class App extends React.Component {
       where qjobid = '${sampleNo}'
       or workorderno = '${sampleNo}'
     `
-    .then(csvParse)
+    .then(tsvParse)
     .then((samples) => samples.forEach((sampleInfo) => this.assemble.run("slim")`
       insert into samples
       (id, partNo, item, customer, status, received_by, received_at)

--- a/src/Sample.js
+++ b/src/Sample.js
@@ -2,7 +2,7 @@ import React from "react"
 import styled from "styled-components"
 
 import Assemble from "./Assemble"
-import csvParse from "./csvParse"
+import { tsvParse } from "./csvParse"
 import TestSpecification from "./TestSpecification"
 
 import List from "@material-ui/core/List"
@@ -44,9 +44,12 @@ class Sample extends React.Component {
     and results.sample_id = samples.id
     where samples.id = '${this.props.id}'
     `((results) => {
-      this.setState({ results: csvParse(results) })
+      this.setState({ results: tsvParse(results) })
 
-      if(this.props.status === 'Received' && csvParse(results).every((spec) => spec.result)) {
+      if(this.props.status === 'Received' &&
+        tsvParse(results).length > 0 &&
+        tsvParse(results).every((spec) => spec.result)
+      ) {
         this.props.onSampleStateChange(this.props.id, 'Completed')
       }
     })

--- a/src/csvParse.js
+++ b/src/csvParse.js
@@ -1,6 +1,6 @@
 // Utility function
 
-const csvParse = (csvData) => {
+const csvParse = (csvData, delimeter = ",") => {
   let lines = csvData.trim().split("\n")
   let headers = lines.shift()
 
@@ -8,8 +8,8 @@ const csvParse = (csvData) => {
   lines.forEach((line) => {
     let result = {}
 
-    headers.split(",").forEach((field, index) => {
-      result[field] = line.split(",")[index]
+    headers.split(delimeter).forEach((field, index) => {
+      result[field] = line.split(delimeter)[index]
     })
 
     results.push(result)
@@ -18,4 +18,7 @@ const csvParse = (csvData) => {
   return results;
 }
 
+const tsvParse = (data) => csvParse(data, "\t")
+
 export default csvParse;
+export { tsvParse }


### PR DESCRIPTION
(tab-separated-values instead of comma-separated-values)

Besides, one of the databases we'll be using in production
returns TSV by default.