### PR TITLE
Change up UI to group specs by part

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -21,7 +21,8 @@ class App extends React.Component {
     samplesForTesting: [],
     releasedSamples: [],
     samplesWithCompletedTests: [],
-    samplesWithoutSpecifications: [],
+    partsWithoutSpecifications: [],
+    partsWithSpecifications: [],
     specifications: [],
     user: undefined,
   }
@@ -112,7 +113,8 @@ class App extends React.Component {
                   />,
                 specify: () =>
                   <Specify
-                    samples={this.state.samplesWithoutSpecifications}
+                    partsWithoutSpecifications={this.state.partsWithoutSpecifications}
+                    partsWithSpecifications={this.state.partsWithSpecifications}
                     specifications={this.state.specifications}
                     onCreateSpecification={(spec) => this.createSpecification(spec)}
                     onRemoveSpec={(spec_id) => {
@@ -180,9 +182,14 @@ class App extends React.Component {
     `((result) => this.setState({ samplesWithCompletedTests: tsvParse(result) }))
 
     this.assemble.watch("slim")`
-      select * from samples
+      select distinct partno, item from samples
       where partno not in (select distinct partno from specification)
-    `((result) => this.setState({ samplesWithoutSpecifications: tsvParse(result) }))
+    `((result) => this.setState({ partsWithoutSpecifications: tsvParse(result) }))
+
+    this.assemble.watch("slim")`
+      select distinct partno, item from samples
+      where partno in (select distinct partno from specification)
+    `((result) => this.setState({ partsWithSpecifications: tsvParse(result) }))
 
     this.assemble.watch("slim")`
       select * from specification

--- a/src/NewSpecForm.js
+++ b/src/NewSpecForm.js
@@ -5,6 +5,12 @@ import TextField from "@material-ui/core/TextField"
 import Button from "@material-ui/core/Button"
 
 class NewSpecForm extends React.Component {
+  constructor(props) {
+    super(props)
+
+    this.state.part = props.prefilledPartNumber || ""
+  }
+
   state = {
     part: "",
     test_name: "",
@@ -16,6 +22,8 @@ class NewSpecForm extends React.Component {
   render() {
     return(
       <Layout>
+        <Layout.Title>Add a new spec</Layout.Title>
+
         <TextField
           label="Part Number"
           onChange={(e) => this.setState({ part: e.target.value })}
@@ -55,9 +63,16 @@ class NewSpecForm extends React.Component {
 }
 
 const Layout = styled.div`
-margin-bottom: 3rem;
-display: flex;
-flex-direction: column;
+  margin-top: 3rem;
+  margin-bottom: 3rem;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-column-gap: 1rem;
+`
+
+Layout.Title = styled.h3`
+  margin-bottom: 1rem;
+  grid-column: 1 / -1;
 `
 
 export default NewSpecForm

--- a/src/Specify.js
+++ b/src/Specify.js
@@ -2,6 +2,11 @@ import React from 'react';
 import styled from "styled-components"
 
 import T from "@material-ui/core/Typography"
+import { Link } from "react-router-dom"
+import List from "@material-ui/core/List"
+import ListItem from "@material-ui/core/ListItem"
+import ListItemText from "@material-ui/core/ListItemText"
+import Card from "@material-ui/core/Card"
 import Button from "@material-ui/core/Button"
 
 import NewSpecForm from "./NewSpecForm"
@@ -11,32 +16,93 @@ import Table from "react-bootstrap-table-next"
 import 'react-bootstrap-table-next/dist/react-bootstrap-table2.min.css';
 
 class Specify extends React.Component {
+  state = { selectedPart: null }
+
   render = () => (
     <Layout>
-      <h2>Active Specs</h2>
+      <Layout.Column>
+        {this.props.partsWithoutSpecifications.length > 0
+          ? <div>
+              <h3>
+                {this.props.partsWithoutSpecifications.length}{" "}
+                part{this.props.partsWithoutSpecifications.length === 1 ? null : "s"}{" "}
+                {this.props.partsWithoutSpecifications.length === 1 ? "has" : "have" }{" "}
+                no specs:
+              </h3>
 
-      <Table keyField="id" data={this.props.specifications} columns={this.tableColumns} />
+              <ListCard>
+                <List>
+                  {this.props.partsWithoutSpecifications.map((part, index) => (
+                    <ListItem
+                      button
+                      divider={index !== this.props.partsWithoutSpecifications.length - 1}
+                      key={part.partno}
+                      onClick={() => this.setState({ selectedPart: part.partno }) }
+                    >
+                      <ListItemText primary={part.item} secondary={`Part ${part.partno}`} />
+                    </ListItem>
+                  ))}
+                </List>
+              </ListCard>
+            </div>
+          : null
+        }
 
-      <h3>Add a new spec</h3>
+        {this.props.partsWithSpecifications.length > 0
+          ? <div>
+              <h3>
+                {this.props.partsWithSpecifications.length}{" "}
+                part{this.props.partsWithSpecifications.length === 1 ? null : "s"}{" "}
+                {this.props.partsWithSpecifications.length === 1 ? "has" : "have" }{" "}
+                specs:
+              </h3>
 
-      {this.props.samples.length > 0
-        ? <T align="left">
-            {this.props.samples.length}{" "}
-            sample{this.props.samples.length === 1 ? null : "s"}{" "}
-            in the lab{" "}
-            {this.props.samples.length === 1 ? "has" : "have" }{" "}
-            no defined testing plan:
-          </T>
-        : null
-      }
+                <ListCard>
+                <List>
+                  {this.props.partsWithSpecifications.map((part, index) => (
+                    <ListItem
+                      button
+                      divider={index !== this.props.partsWithSpecifications.length - 1}
+                      key={part.partno}
+                      onClick={() => this.setState({ selectedPart: part.partno }) }
+                    >
+                      <ListItemText primary={part.item} secondary={`Part ${part.partno}`} />
+                    </ListItem>
+                  ))}
+                </List>
+              </ListCard>
+            </div>
+          : null
+        }
+      </Layout.Column>
 
-      <ul>
-        {this.props.samples.map((sample) => (
-          <li key={sample.id}>{sample.id} (Part {sample.partno})</li>
-        ))}
-      </ul>
+      <Layout.Column>
+        {this.state.selectedPart
+        ? <div>
+            <h2>Active Specs</h2>
 
-      <NewSpecForm onCreateSpecification={this.props.onCreateSpecification} />
+            <Table
+              keyField="id"
+              data={this.props.specifications.filter((spec) => (
+                spec.partno === this.state.selectedPart
+              ))}
+              columns={this.tableColumns}
+            />
+
+            <NewSpecForm
+              prefilledPartNumber={this.state.selectedPart}
+              onCreateSpecification={this.props.onCreateSpecification}
+            />
+          </div>
+        : <div>
+            <T>Select a part to see its testing plan.</T>
+            <T>
+              You may need to <Link to="/receive">scan some items into the system</Link>{" "}
+              if there aren't any already.
+            </T>
+          </div>
+        }
+      </Layout.Column>
     </Layout>
   )
 
@@ -69,6 +135,16 @@ class Specify extends React.Component {
 }
 
 const Layout = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 2fr;
+  grid-column-gap: 1rem;
+`
+
+Layout.Column = styled.div`
+`
+
+const ListCard = styled(Card)`
+margin-bottom: 2rem;
 `
 
 export default Specify


### PR DESCRIPTION
This is a pre-requisite for #58.

We want the spec page to resemble the actual specification documents
as closely as possible.

The actual specs each describe a single part,
so we should group our specs by part as well.

* Pre-fill the part number for the new spec form
* Filter specs list by part number