### PR TITLE
Switch back to `localstorage.removeItem()`

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -34,9 +34,9 @@ class App extends React.Component {
           <Sidebar
             user={this.state.user}
             onSignOut={() => {
-              localStorage.user_id = null
-              localStorage.user_name = null
-              localStorage.user_username = null
+              localStorage.removeItem("user_id")
+              localStorage.removeItem("user_name")
+              localStorage.removeItem("user_username")
               this.setState({ user: null })
             }}
             onReset={() => {


### PR DESCRIPTION
It turns out `localStorage.item = null` doesn't have the same effect
as `localStorage.removeItem()`.

With `localStorage.item = null`, we were getting
"Signed in as null" displaying in the sidebar,
along with the link to sign out.
There was no way to clear out the signed-in "null" user,
except for manually deleting the localStorage variables
through the developer tools.

The other direct calls to `localStorage` seem to work fine.

Bug introduced in #54.