### PR TITLE
Permanent links to samples

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -104,8 +104,8 @@ class App extends React.Component {
             }}
           />} />
 
-          <Route path="/sample/:id" component={({ match }) => {
-            return <StandaloneSample id={match.params.id} />
+          <Route path="/sample/:subpath*" component={({ match }) => {
+            return <StandaloneSample id={match.params.subpath} />
           }} />
 
           {this.state.user

--- a/src/App.js
+++ b/src/App.js
@@ -6,6 +6,7 @@ import Assemble from "./Assemble"
 import History from "./History"
 import Receive from "./Receive"
 import Release from "./Release"
+import StandaloneSample from "./StandaloneSample"
 import Sidebar from "./Sidebar"
 import SignIn from "./SignIn"
 import Specify from "./Specify"
@@ -102,6 +103,10 @@ class App extends React.Component {
               this.setState({ user: user })
             }}
           />} />
+
+          <Route path="/sample/:id" component={({ match }) => {
+            return <StandaloneSample id={match.params.id} />
+          }} />
 
           {this.state.user
           ?  <TabView

--- a/src/Sample.js
+++ b/src/Sample.js
@@ -15,15 +15,15 @@ import ExpansionPanelActions from "@material-ui/core/ExpansionPanelActions"
 import ExpansionPanelDetails from "@material-ui/core/ExpansionPanelDetails"
 import ExpansionPanelSummary from "@material-ui/core/ExpansionPanelSummary"
 
-import Avatar from "@material-ui/core/Avatar"
-
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore"
 import Fail from "@material-ui/icons/Close"
 import LinkIcon from "@material-ui/icons/Link"
 import Pass from "@material-ui/icons/Check"
 
+import Avatar from "@material-ui/core/Avatar"
 import Button from "@material-ui/core/Button"
 import T from "@material-ui/core/Typography"
+import Tooltip from '@material-ui/core/Tooltip';
 
 class Sample extends React.Component {
   assemble = new Assemble("https://localhost:3000")
@@ -78,14 +78,17 @@ class Sample extends React.Component {
           <SummaryRight>
             <T variant="caption" align="right">Part {this.props.partno}</T>
             <T variant="subheading" align="right">
-              <Button
-                onClick={(e) => {
-                  e.stopPropagation();
-                  copyTextToClipboard(`${window.location.origin}/sample/${this.props.id}`);
-                }}
-              >
-                <LinkIcon />
-              </Button>
+
+              <Tooltip title={`Copy a permanent link to ${this.props.id}`}>
+                <Button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    copyTextToClipboard(`${window.location.origin}/sample/${this.props.id}`);
+                  }}
+                >
+                  <LinkIcon />
+                </Button>
+              </Tooltip>
 
               {this.props.id.toUpperCase()}
             </T>

--- a/src/Sample.js
+++ b/src/Sample.js
@@ -3,20 +3,26 @@ import styled from "styled-components"
 
 import Assemble from "./Assemble"
 import { tsvParse } from "./csvParse"
+import copyTextToClipboard from "./copyTextToClipboard"
 import TestSpecification from "./TestSpecification"
 
 import List from "@material-ui/core/List"
 import ListItem from "@material-ui/core/ListItem"
 import ListItemText from "@material-ui/core/ListItemText"
-import Avatar from "@material-ui/core/Avatar"
-import Pass from "@material-ui/icons/Check"
-import Fail from "@material-ui/icons/Close"
 
-import ExpandMoreIcon from "@material-ui/icons/ExpandMore"
 import ExpansionPanel from "@material-ui/core/ExpansionPanel"
 import ExpansionPanelActions from "@material-ui/core/ExpansionPanelActions"
 import ExpansionPanelDetails from "@material-ui/core/ExpansionPanelDetails"
 import ExpansionPanelSummary from "@material-ui/core/ExpansionPanelSummary"
+
+import Avatar from "@material-ui/core/Avatar"
+
+import ExpandMoreIcon from "@material-ui/icons/ExpandMore"
+import Fail from "@material-ui/icons/Close"
+import LinkIcon from "@material-ui/icons/Link"
+import Pass from "@material-ui/icons/Check"
+
+import Button from "@material-ui/core/Button"
 import T from "@material-ui/core/Typography"
 
 class Sample extends React.Component {
@@ -71,7 +77,18 @@ class Sample extends React.Component {
 
           <SummaryRight>
             <T variant="caption" align="right">Part {this.props.partno}</T>
-            <T variant="subheading" align="right">{this.props.id.toUpperCase()}</T>
+            <T variant="subheading" align="right">
+              <Button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  copyTextToClipboard(`${window.location.origin}/sample/${this.props.id}`);
+                }}
+              >
+                <LinkIcon />
+              </Button>
+
+              {this.props.id.toUpperCase()}
+            </T>
           </SummaryRight>
         </ExpansionPanelSummary>
 

--- a/src/Sample.js
+++ b/src/Sample.js
@@ -61,7 +61,7 @@ class Sample extends React.Component {
 
   render() {
     return (
-      <ExpansionPanel>
+      <ExpansionPanel defaultExpanded={this.props.expanded}>
         <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
           <div>
             <T variant="caption" align="left">{this.props.customer}</T>

--- a/src/Sample.js
+++ b/src/Sample.js
@@ -1,6 +1,11 @@
 import React from "react"
 import styled from "styled-components"
 
+// The sample detects whether it should be expanded or not
+// based on whether the current route's params include `{ subpath: "Q123456" }`,
+// where `"Q123456"` is the sample's ID.
+import { withRouter } from "react-router-dom"
+
 import Assemble from "./Assemble"
 import { tsvParse } from "./csvParse"
 import copyTextToClipboard from "./copyTextToClipboard"
@@ -67,7 +72,9 @@ class Sample extends React.Component {
 
   render() {
     return (
-      <ExpansionPanel defaultExpanded={this.props.expanded}>
+      <ExpansionPanel
+        defaultExpanded={this.props.match.params.subpath === this.props.id}
+      >
         <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
           <div>
             <T variant="caption" align="left">{this.props.customer}</T>
@@ -173,4 +180,4 @@ const RedAvatar = styled(Avatar)`
 background-color: red !important;
 `
 
-export default Sample
+export default withRouter(Sample)

--- a/src/StandaloneSample.js
+++ b/src/StandaloneSample.js
@@ -1,0 +1,54 @@
+import React from "react"
+import styled from "styled-components"
+
+import Assemble from "./Assemble"
+import Sample from "./Sample"
+import T from "@material-ui/core/Typography"
+import { Link } from "react-router-dom"
+import { tsvParse } from "./csvParse"
+
+class StandaloneSample extends React.Component {
+  assemble = new Assemble("https://localhost:3000")
+
+  state = { sample: null }
+
+  componentDidMount() {
+    this.assemble.watch("slim")`
+    select * from samples
+    where id = '${this.props.id}'
+    `((result) => {
+      this.setState({ sample: tsvParse(result)[0] })
+    })
+  }
+
+  render = () => (
+    <Layout>
+      { this.state.sample
+      ? <Sample {...this.state.sample} disabled expanded >
+          <Link to={`/${this.step().toLowerCase()}/${this.props.id}`}>
+            View on the {this.step()} page
+          </Link>
+        </Sample>
+      : <T>Loading...</T>
+      }
+    </Layout>
+  )
+
+  step = () => (
+    {
+      "Received": "Test",
+      "Completed": "Release",
+      "Released": "History",
+    }[this.state.sample.status]
+  )
+
+  componentWillUnmount() {
+    this.assemble.destruct()
+  }
+}
+
+const Layout = styled.div`
+margin-top: 3rem;
+`
+
+export default StandaloneSample

--- a/src/StandaloneSample.js
+++ b/src/StandaloneSample.js
@@ -24,7 +24,7 @@ class StandaloneSample extends React.Component {
   render = () => (
     <Layout>
       { this.state.sample
-      ? <Sample {...this.state.sample} disabled expanded >
+      ? <Sample {...this.state.sample} disabled >
           <Link to={`/${this.step().toLowerCase()}/${this.props.id}`}>
             View on the {this.step()} page
           </Link>

--- a/src/TabView.js
+++ b/src/TabView.js
@@ -26,7 +26,7 @@ class TabView extends React.Component {
           { Object.keys(this.props.tabs).map((tab) => (
             <Route
               key={tab}
-              path={base_url + "/" + tab}
+              path={base_url + "/" + tab + "/:subpath*"}
               component={this.props.tabs[tab]}
             />
           ))}

--- a/src/copyTextToClipboard.js
+++ b/src/copyTextToClipboard.js
@@ -1,0 +1,33 @@
+// Borrowed from Dean Taylor,
+// https://stackoverflow.com/a/30810322
+
+function fallbackCopyTextToClipboard(text) {
+  var textArea = document.createElement("textarea");
+  textArea.value = text;
+  document.body.appendChild(textArea);
+  textArea.focus();
+  textArea.select();
+
+  try {
+    var successful = document.execCommand('copy');
+    var msg = successful ? 'successful' : 'unsuccessful';
+    console.log('Fallback: Copying text command was ' + msg);
+  } catch (err) {
+    console.error('Fallback: Oops, unable to copy', err);
+  }
+
+  document.body.removeChild(textArea);
+}
+function copyTextToClipboard(text) {
+  if (!navigator.clipboard) {
+    fallbackCopyTextToClipboard(text);
+    return;
+  }
+  navigator.clipboard.writeText(text).then(function() {
+    console.log('Async: Copying to clipboard was successful!');
+  }, function(err) {
+    console.error('Async: Could not copy text: ', err);
+  });
+}
+
+export default copyTextToClipboard


### PR DESCRIPTION
Each sample now has a button
which will copy a link to the clipboard.

The link takes users to a page dedicated to the sample.

The dedicated sample page is read-only.
In order to take action on the sample (e.g. enter test results, release),
the user must navigate to the sample on one of the step pages.

Closes #29